### PR TITLE
TLP-816: Zap OWASP Image Deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/zap2docker-stable
+FROM zaproxy/zap-bare:2.15.0
 
 # WORKDIR /var/www
 

--- a/src/Zap/Core.php
+++ b/src/Zap/Core.php
@@ -54,7 +54,7 @@ class Core {
 		if ($count !== NULL) {
 			$params['count'] = $count;
 		}
-		$res = $this->zap->request($this->zap->base . 'core/view/alerts/', $params);
+		$res = $this->zap->request($this->zap->base . 'alert/view/alerts/', $params);
 		return reset($res);
 	}
 
@@ -68,7 +68,7 @@ class Core {
 			$params['baseurl'] = $baseurl;
 		}
 
-		$res = $this->zap->request($this->zap->base . 'core/view/alertsSummary/', $params);
+		$res = $this->zap->request($this->zap->base . 'alert/view/alertsSummary/', $params);
 		
 		return reset($res);
 	}
@@ -81,7 +81,7 @@ class Core {
 		if ($baseurl !== NULL) {
 			$params['baseurl'] = $baseurl;
 		}
-		$res = $this->zap->request($this->zap->base . 'core/view/numberOfAlerts/', $params);
+		$res = $this->zap->request($this->zap->base . 'alert/view/numberOfAlerts/', $params);
 		return reset($res);
 	}
 


### PR DESCRIPTION
### Zap OWASP Image Deprecated

Zaproxy (ZAP Bare) image is outdated and needs to be replaced with new version 2.15.

**Jira Link**
[TLP-816](https://gigadatsolutions.atlassian.net/browse/TLP-816)


[TLP-816]: https://gigadatsolutions.atlassian.net/browse/TLP-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ